### PR TITLE
0.5.1 apple m1 install - closes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ detections with the default model, try using the `BACK_CAMERA`-model instead.
 
 ## Installation
 
-The latest release version is available in [PyPI](https://pypi.org/project/face-detection-tflite/0.1.0/)
+The latest release version is available in [PyPI](https://pypi.org/project/face-detection-tflite/0.5.1/)
 and can be installed via:
 
 ```sh

--- a/fdlite/__init__.py
+++ b/fdlite/__init__.py
@@ -13,4 +13,4 @@ from .iris_landmark import iris_landmarks_to_render_data          # noqa:F401
 from .iris_landmark import iris_roi_from_face_landmarks           # noqa:F401
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,10 @@ packages = find:
 python_requires = >= 3.7
 include_package_data = true
 install_requires =
-    tensorflow >= 2.3 ; platform_system!="Darwin"
-    tensorflow-macos >= 2.3 ; platform_system=="Darwin"
-    tensorflow-metal >= 2.3 ; platform_machine=="arm64"
+    tensorflow >= 2.5 ; platform_system!="Darwin"
+    tensorflow-deps ; platform_system=="Darwin"
+    tensorflow-macos ; platform_system=="Darwin"
+    tensorflow-metal ; platform_machine=="arm64"
     Pillow >= 8.0
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [metadata]
 name = face-detection-tflite
-version = 0.5.0
+version = 0.5.1
 author = Patrick Levin
 author_email = vertical-pink@protonmail.com
 description = A Python port of Google MediaPipe Face Detection modules
@@ -29,7 +29,7 @@ packages = find:
 python_requires = >= 3.7
 include_package_data = true
 install_requires =
-    tensorflow >= 2.3 ; platform_system~="Darwin"
+    tensorflow >= 2.3 ; platform_system!="Darwin"
     tensorflow-macos >= 2.3 ; platform_system=="Darwin"
     tensorflow-metal >= 2.3 ; platform_machine=="arm64"
     Pillow >= 8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,10 @@ packages = find:
 python_requires = >= 3.7
 include_package_data = true
 install_requires =
-    tensorflow>=2.3
-    Pillow>=8.0
+    tensorflow >= 2.3 ; platform_system~="Darwin"
+    tensorflow-macos >= 2.3 ; platform_system=="Darwin"
+    tensorflow-metal >= 2.3 ; platform_machine=="arm64"
+    Pillow >= 8.0
 
 [flake8]
 exclude =


### PR DESCRIPTION
# Support for Installation on Apple Silicon Macs

As pointed out in Issue #8, Apple maintains their own fork of Tensorflow for their latest ARM-based processors.

The previous packaging didn't account for platform-specific dependencies.

## Changes

1. Add platform-specific dependencies for MacOS
2. Add platform-specific dependencies for ARM-based Macs
3. Update package version to allow for clean install