### PR TITLE
Update Pillow version to 9.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >= 3.7
 include_package_data = true
 install_requires =
     tensorflow>=2.3
-    Pillow>=8.0
+    Pillow==9.5.0
 
 [flake8]
 exclude =


### PR DESCRIPTION
This resolves the issue #11 

Context :
When used this model for the latest version of pillow it gives a call for error stating 
`2024-03-29 16:38:49.105398: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2024-03-29 16:38:49.236544: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2024-03-29 16:38:49.239620: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2024-03-29 16:38:49.239638: I tensorflow/compiler/xla/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2024-03-29 16:38:49.679165: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory
2024-03-29 16:38:49.679216: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory
2024-03-29 16:38:49.679221: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Traceback (most recent call last):
  File "/home/adithyahegdekota/Documents/GitHub/Multi-Face-Detection-and-Separation-System-MFDeSS-/test.py", line 7, in <module>
    faces = detect_faces(image)
  File "/home/adithyahegdekota/.local/lib/python3.10/site-packages/fdlite/face_detection.py", line 214, in __call__
    image_data = image_to_tensor(
  File "/home/adithyahegdekota/.local/lib/python3.10/site-packages/fdlite/transform.py", line 66, in image_to_tensor
    data=coeffs, resample=Image.LINEAR)
AttributeError: module 'PIL.Image' has no attribute 'LINEAR'. Did you mean: 'BILINEAR'?`


This PR solves the above Issue Specific 9.5.0 is chosen such that it is even compatible with Image Renderer.

